### PR TITLE
Add sensible defaults for not required params in scala

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/api.mustache
@@ -31,7 +31,7 @@ class {{classname}}(val defBasePath: String = "{{{basePath}}}",
 {{#allParams}}   * @param {{paramName}} {{description}} {{^required}}(optional{{#defaultValue}}, default to {{{.}}}{{/defaultValue}}){{/required}}
 {{/allParams}}   * @return {{#returnType}}{{{returnType}}}{{/returnType}}{{^returnType}}void{{/returnType}}
    */
-  def {{operationId}}({{#allParams}}{{paramName}}: {{#required}}{{dataType}}{{#defaultValue}} /* = {{{defaultValue}}}*/{{/defaultValue}}{{/required}}{{^required}}Option[{{dataType}}]{{#defaultValue}} /* = {{{defaultValue}}}*/{{/defaultValue}}{{^defaultValue}} = None{{/defaultValue}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}: Option[{{returnType}}]{{/returnType}} = {
+  def {{operationId}}({{#allParams}}{{paramName}}: {{#required}}{{dataType}}{{#defaultValue}} /* = {{{defaultValue}}}*/{{/defaultValue}}{{/required}}{{^required}}Option[{{dataType}}]{{#defaultValue}} = None /* = {{{defaultValue}}}*/{{/defaultValue}}{{^defaultValue}} = None{{/defaultValue}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/allParams}}){{#returnType}}: Option[{{returnType}}]{{/returnType}} = {
     // create path and map variables
     val path = "{{{path}}}".replaceAll("\\{format\\}", "json"){{#pathParams}}.replaceAll("\\{" + "{{baseName}}" + "\\}",apiInvoker.escape({{paramName}})){{/pathParams}}
 
@@ -72,7 +72,7 @@ class {{classname}}(val defBasePath: String = "{{{basePath}}}",
     {{/required}}
     {{/headerParams}}
 
-    var postBody: AnyRef = {{#bodyParam}}{{#required}}{{paramName}}{{/required}}{{^required}}{{paramName}}.map(paramVal => paramVal){{/required}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}
+    var postBody: AnyRef = {{#bodyParam}}{{#required}}{{paramName}}{{/required}}{{^required}}{{paramName}}.map(paramVal => paramVal).getOrElse(null){{/required}}{{/bodyParam}}{{^bodyParam}}null{{/bodyParam}}
 
     if (contentType.startsWith("multipart/form-data")) {
       val mp = new FormDataMultiPart


### PR DESCRIPTION
Fixes https://github.com/elastic/cloud/issues/6732

Optional params with defaults now default to `None` so you don't have to specify them (and ie the server will default them)

Optional body now has `.getOrElse(null)` to stop if from inserting `"null"` into the body