### PR TITLE
Added support for http PATCH to the scala client using override header

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
@@ -145,6 +145,11 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
       case "DELETE" => {
         builder.delete(classOf[ClientResponse])
       }
+      case "PATCH" => {
+        if(formData != null) builder.header("X-HTTP-Method-Override", "PATCH").post(classOf[ClientResponse], formData)
+        else if(body == null) builder.header("X-HTTP-Method-Override", "PATCH").post(classOf[ClientResponse], null)
+        else builder.header("X-HTTP-Method-Override", "PATCH").`type`(contentType).post(classOf[ClientResponse], serialize(body))
+      }
       case _ => null
     }
     response.getStatusInfo().getStatusCode() match {


### PR DESCRIPTION
The jersey API client used by the scala swagger client does not support the `PATCH` http verb, this PR uses the same approach as the java client and treats a `PATCH` as a `POST` together with setting the `X-HTTP-Method-Override` header to `PATCH`.
