### PR TITLE
Update scala mapper for null type serialization

### DIFF
--- a/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
@@ -25,12 +25,47 @@ import com.fasterxml.jackson.core.JsonGenerator.Feature
 import com.fasterxml.jackson.databind._
 import com.fasterxml.jackson.annotation._
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.core.JsonGenerator
+
+
+private class CustomSomeSerializer extends StdSerializer[Some[_]](classOf[Some[_]]) {
+  override def serialize(
+    value: Some[_],
+    gen: JsonGenerator,
+    provider: SerializerProvider
+  ): Unit = {
+    value match {
+      case Some(x) if x == null => provider.defaultSerializeNull(gen)
+      case Some(x) => provider.defaultSerializeValue(x, gen)
+    }
+  }
+}
+
+
+private class CustomModifier extends BeanSerializerModifier {
+  override def modifySerializer(
+    config: SerializationConfig,
+    beanDesc: BeanDescription,
+    serializer: JsonSerializer[_]
+  ): JsonSerializer[_] = {
+    beanDesc.getBeanClass match {
+      case c if c == classOf[Some[_]] => new CustomSomeSerializer
+      case _ => serializer
+    }
+  }
+}
 
 object ScalaJsonUtil {
   def getJsonMapper = {
     val mapper = new ObjectMapper()
+    val customModule = new SimpleModule("custom module")
+    customModule.setSerializerModifier(new CustomModifier)
     mapper.registerModule(new DefaultScalaModule())
     mapper.registerModule(new JodaModule());
+    mapper.registerModule(customModule)
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.setSerializationInclusion(JsonInclude.Include.NON_DEFAULT)
     mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)


### PR DESCRIPTION
When passing null values to a payload, we have to differentiate them from a scala None type which do not have the same meaning (null value vs lack of value).
With this PR, the swagger api client will be able to make a difference between `Some(null)` and `None`.

For example, given the class Foo:
```scala
case class Foo(a: Option[Int] = None, b: Option[Int] = None)
```

the serialization of 

```scala
Foo(a = Some(null.asInstanceOf[Int]))
```

will give us 

```json
{"a":null}
```

instead of an empty object.

This PR will help us to add some integration tests relative to this issue elastic/cloud#19490

