### PR TITLE
Fix: Scala client support for DELETE requests with payload

### DIFF
--- a/modules/swagger-codegen-cli/pom.xml
+++ b/modules/swagger-codegen-cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.5-elastic-cloud</version>
+        <version>2.2.6-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen-maven-plugin/pom.xml
+++ b/modules/swagger-codegen-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.5-elastic-cloud</version>
+        <version>2.2.6-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-codegen-maven-plugin</artifactId>

--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.5-elastic-cloud</version>
+        <version>2.2.6-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
@@ -178,7 +178,8 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
         else builder.`type`(contentType).put(classOf[ClientResponse], serialize(body))
       }
       case "DELETE" => {
-        builder.delete(classOf[ClientResponse])
+        if(body == null) builder.delete(classOf[ClientResponse])
+        else builder.`type`(contentType).delete(classOf[ClientResponse], serialize(body))
       }
       case "PATCH" => {
         if(formData != null) builder.header("X-HTTP-Method-Override", "PATCH").post(classOf[ClientResponse], formData)

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.5-elastic-cloud</version>
+        <version>2.2.6-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>swagger-codegen-project</artifactId>
     <packaging>pom</packaging>
     <name>swagger-codegen-project</name>
-    <version>2.2.5-elastic-cloud</version>
+    <version>2.2.6-elastic-cloud</version>
     <url>https://github.com/elastic/swagger-codegen</url>
     <scm>
         <connection>scm:git:git@github.com:elastic/swagger-codegen.git</connection>

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/ApiResponse.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/ApiResponse.scala
@@ -14,8 +14,8 @@ package io.swagger.client.model
 
 
 case class ApiResponse (
-  code: Option[Integer],
-  _type: Option[String],
-  message: Option[String]
+  code: Option[Integer] = None,
+  _type: Option[String] = None,
+  message: Option[String] = None
 )
 

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Category.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Category.scala
@@ -14,7 +14,7 @@ package io.swagger.client.model
 
 
 case class Category (
-  id: Option[Long],
-  name: Option[String]
+  id: Option[Long] = None,
+  name: Option[String] = None
 )
 

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Order.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Order.scala
@@ -15,12 +15,12 @@ package io.swagger.client.model
 import org.joda.time.DateTime
 
 case class Order (
-  id: Option[Long],
-  petId: Option[Long],
-  quantity: Option[Integer],
-  shipDate: Option[DateTime],
+  id: Option[Long] = None,
+  petId: Option[Long] = None,
+  quantity: Option[Integer] = None,
+  shipDate: Option[DateTime] = None,
   /* Order Status */
-  status: Option[String],
-  complete: Option[Boolean]
+  status: Option[String] = None,
+  complete: Option[Boolean] = None
 )
 

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Pet.scala
@@ -14,12 +14,12 @@ package io.swagger.client.model
 
 
 case class Pet (
-  id: Option[Long],
-  category: Option[Category],
+  id: Option[Long] = None,
+  category: Option[Category] = None,
   name: String,
   photoUrls: List[String],
-  tags: Option[List[Tag]],
+  tags: Option[List[Tag]] = None,
   /* pet status in the store */
-  status: Option[String]
+  status: Option[String] = None
 )
 

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Tag.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/Tag.scala
@@ -14,7 +14,7 @@ package io.swagger.client.model
 
 
 case class Tag (
-  id: Option[Long],
-  name: Option[String]
+  id: Option[Long] = None,
+  name: Option[String] = None
 )
 

--- a/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/User.scala
+++ b/samples/client/petstore/scala/src/main/scala/io/swagger/client/model/User.scala
@@ -14,14 +14,14 @@ package io.swagger.client.model
 
 
 case class User (
-  id: Option[Long],
-  username: Option[String],
-  firstName: Option[String],
-  lastName: Option[String],
-  email: Option[String],
-  password: Option[String],
-  phone: Option[String],
+  id: Option[Long] = None,
+  username: Option[String] = None,
+  firstName: Option[String] = None,
+  lastName: Option[String] = None,
+  email: Option[String] = None,
+  password: Option[String] = None,
+  phone: Option[String] = None,
   /* User Status */
-  userStatus: Option[Integer]
+  userStatus: Option[Integer] = None
 )
 


### PR DESCRIPTION
### Description of the PR
Added support for DELETE requests with a payload.  Our current client ignores the payload on  DELETE requests if any.

None of the upstream projects [swagger-code-gen](https://github.com/swagger-api/swagger-codegen/blob/master/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache#L158) or [open-api version](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/scala-httpclient/apiInvoker.mustache#L158) supports Scala clients with a payload in `DELETE`

But Java clients in both [seem to support it](https://github.com/swagger-api/swagger-codegen/blob/master/samples/client/petstore/android/volley/src/main/java/io/swagger/client/ApiInvoker.java#L483).

Pre-requisite for https://github.com/elastic/cloud/pull/28291
