### PR TITLE
Fix: cloud-release is where cloud assets go on central artifactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -905,13 +905,13 @@
     <distributionManagement>
         <repository>
             <id>central</id>
-            <name>artifactory.elstc.co-releases</name>
-            <url>https://artifactory.elstc.co/artifactory/libs-release-local</url>
+            <name>artifactory.elstc.co-cloud-releases</name>
+            <url>https://artifactory.elstc.co/artifactory/cloud-release-local</url>
         </repository>
         <snapshotRepository>
             <id>snapshots</id>
-            <name>artifactory.elstc.co-snapshots</name>
-            <url>https://artifactory.elstc.co/artifactory/libs-snapshot-local</url>
+            <name>artifactory.elstc.co-cloud-snapshots</name>
+            <url>https://artifactory.elstc.co/artifactory/cloud-snapshot-local</url>
         </snapshotRepository>
     </distributionManagement>
     <repositories>


### PR DESCRIPTION
### Description of the PR

The new artifactory has separate space for Cloud assets and also evidenced by [Co-ordinates on Cloud build.sbt](https://github.com/elastic/cloud/blob/master/scala-services/project/build.sbt#L4)

The [permissions for the new bot user ](https://github.com/elastic/infra/issues/10946#issuecomment-485737198) were also given to `*local` of these repositories.

So this is a bugfix than a refactoring.
