### PR TITLE
22628 - add scala gatling codegen for version 2.2.7-elastic-cloud

### DIFF
--- a/modules/swagger-codegen-cli/pom.xml
+++ b/modules/swagger-codegen-cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.6-elastic-cloud</version>
+        <version>2.2.7-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen-maven-plugin/pom.xml
+++ b/modules/swagger-codegen-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.6-elastic-cloud</version>
+        <version>2.2.7-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-codegen-maven-plugin</artifactId>

--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.6-elastic-cloud</version>
+        <version>2.2.7-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaGatlingCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaGatlingCodegen.java
@@ -239,8 +239,8 @@ public class ScalaGatlingCodegen extends AbstractScalaCodegen implements Codegen
                         if (model instanceof RefModel) {
                             String[] refArray = model.getReference().split("\\/");
                             operation.setVendorExtension("x-gatling-body-object", refArray[refArray.length - 1] + ".toStringBody");
-                            Set<String> bodyFeederParams = new HashSet<>();
-                            Set<String> sessionBodyVars = new HashSet<>();
+                            Set<String> bodyFeederParams = new LinkedHashSet<>();
+                            Set<String> sessionBodyVars = new LinkedHashSet<>();
                             for (Map.Entry<String, Model> modelEntry : swagger.getDefinitions().entrySet()) {
                                 if (refArray[refArray.length - 1].equalsIgnoreCase(modelEntry.getKey())) {
                                     for (Map.Entry<String, Property> propertyEntry : modelEntry.getValue().getProperties().entrySet()) {

--- a/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaGatlingCodegen.java
+++ b/modules/swagger-codegen/src/main/java/io/swagger/codegen/languages/ScalaGatlingCodegen.java
@@ -1,0 +1,345 @@
+package io.swagger.codegen.languages;
+
+import io.swagger.codegen.*;
+import io.swagger.models.*;
+import io.swagger.models.parameters.*;
+import io.swagger.models.properties.*;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.util.*;
+import java.io.File;
+
+public class ScalaGatlingCodegen extends AbstractScalaCodegen implements CodegenConfig {
+
+    // source folder where to write the files
+    protected String sourceFolder = "src" + File.separator + "gatling" + File.separator + "scala";
+    protected String resourceFolder = "src" + File.separator + "gatling" + File.separator + "resources";
+    protected String confFolder = resourceFolder + File.separator + "conf";
+    protected String dataFolder = resourceFolder + File.separator + "data";
+    protected String apiVersion = "1.0.0";
+
+    /**
+     * Configures the type of generator.
+     *
+     * @return the CodegenType for this generator
+     * @see io.swagger.codegen.CodegenType
+     */
+    public CodegenType getTag() {
+        return CodegenType.CLIENT;
+    }
+
+    /**
+     * Configures a friendly name for the generator.  This will be used by the generator
+     * to select the library with the -l flag.
+     *
+     * @return the friendly name for the generator
+     */
+    public String getName() {
+        return "scala-gatling";
+    }
+
+    /**
+     * Returns human-friendly help for the generator.  Provide the consumer with help
+     * tips, parameters here
+     *
+     * @return A string value for the help message
+     */
+    public String getHelp() {
+        return "Generates a gatling simulation library (beta).";
+    }
+
+    public ScalaGatlingCodegen() {
+        super();
+
+        // set the output folder here
+        outputFolder = "generated-code/gatling";
+
+        /**
+         * Api classes.  You can write classes for each Api file with the apiTemplateFiles map.
+         * as with models, add multiple entries with different extensions for multiple files per
+         * class
+         */
+        apiTemplateFiles.put(
+                "api.mustache",   // the template to use
+                "Operations.scala");       // the extension for each file to write
+
+        modelTemplateFiles.put("model.mustache", ".scala");
+
+        /**
+         * Template Location.  This is the location which templates will be read from.  The generator
+         * will use the resource stream to attempt to read the templates.
+         */
+        templateDir = "scala-gatling";
+
+        /**
+         * Api Package.  Optional, if needed, this can be used in templates
+         */
+        apiPackage = "io.swagger.client.api";
+
+        /**
+         * Model Package.  Optional, if needed, this can be used in templates
+         */
+        modelPackage = "io.swagger.client.model";
+
+        /**
+         * Additional Properties.  These values can be passed to the templates and
+         * are available in models, apis, and supporting files
+         */
+        additionalProperties.put("apiVersion", apiVersion);
+
+        /**
+         * Supporting Files.  You can write single files for the generator with the
+         * entire object tree available.  If the input file has a suffix of `.mustache
+         * it will be processed by the template engine.  Otherwise, it will be copied
+         */
+        supportingFiles.add(new SupportingFile("build.gradle",
+                "",
+                "build.gradle"));
+        supportingFiles.add(new SupportingFile("logback.xml",
+                confFolder,
+                "logback.xml"));
+        supportingFiles.add(new SupportingFile("default.conf.mustache",
+                confFolder,
+                "default.conf"));
+        supportingFiles.add(new SupportingFile("default.conf.mustache",
+                confFolder,
+                "CI.conf"));
+        supportingFiles.add(new SupportingFile("default.conf.mustache",
+                confFolder,
+                "CD.conf"));
+        supportingFiles.add(new SupportingFile("default.conf.mustache",
+                confFolder,
+                "stress.conf"));
+        supportingFiles.add(new SupportingFile("default.conf.mustache",
+                confFolder,
+                "baseline.conf"));
+        supportingFiles.add(new SupportingFile("default.conf.mustache",
+                confFolder,
+                "longevity.conf"));
+
+
+        importMapping.remove("List");
+        importMapping.remove("Set");
+        importMapping.remove("Map");
+
+        importMapping.put("Date", "java.util.Date");
+        importMapping.put("ListBuffer", "scala.collection.mutable.ListBuffer");
+
+        typeMapping = new HashMap<String, String>();
+        typeMapping.put("enum", "NSString");
+        typeMapping.put("array", "List");
+        typeMapping.put("set", "Set");
+        typeMapping.put("boolean", "Boolean");
+        typeMapping.put("string", "String");
+        typeMapping.put("int", "Int");
+        typeMapping.put("long", "Long");
+        typeMapping.put("float", "Float");
+        typeMapping.put("byte", "Byte");
+        typeMapping.put("short", "Short");
+        typeMapping.put("char", "Char");
+        typeMapping.put("double", "Double");
+        typeMapping.put("object", "Any");
+        typeMapping.put("file", "File");
+        typeMapping.put("binary", "String");
+        typeMapping.put("ByteArray", "String");
+        typeMapping.put("date-time", "Date");
+        typeMapping.put("DateTime", "Date");
+
+        instantiationTypes.put("array", "ListBuffer");
+        instantiationTypes.put("map", "HashMap");
+
+        setReservedWordsLowerCase(
+                Arrays.asList(
+                        // local variable names used in API methods (endpoints)
+                        "path", "contentTypes", "contentType", "queryParams", "headerParams",
+                        "formParams", "postBody", "mp", "basePath", "apiInvoker",
+
+                        // scala reserved words
+                        "abstract", "case", "catch", "class", "def", "do", "else", "extends",
+                        "false", "final", "finally", "for", "forSome", "if", "implicit",
+                        "import", "lazy", "match", "new", "null", "object", "override", "package",
+                        "private", "protected", "return", "sealed", "super", "this", "throw",
+                        "trait", "try", "true", "type", "val", "var", "while", "with", "yield")
+        );
+    }
+
+    /**
+     * Gatling does not need the models to have escaped words as it builds models dynamically instead of through
+     * an instance of the object.
+     *
+     * @return the escaped term
+     */
+    @Override
+    public String escapeReservedWord(String name) {
+        return name;
+    }
+
+    /**
+     * Location to write model files.  You can use the modelPackage() as defined when the class is
+     * instantiated
+     */
+    public String modelFileFolder() {
+        return outputFolder + "/" + sourceFolder + "/" + modelPackage().replace('.', File.separatorChar);
+    }
+
+    /**
+     * Location to write api files.  You can use the apiPackage() as defined when the class is
+     * instantiated
+     */
+    @Override
+    public String apiFileFolder() {
+        return outputFolder + "/" + sourceFolder + "/" + apiPackage().replace('.', File.separatorChar);
+    }
+
+    /**
+     * Modifies the swagger doc to make mustache easier to use
+     *
+     * @param swagger input swagger document
+     */
+    @Override
+    public void preprocessSwagger(Swagger swagger) {
+        for (String pathname : swagger.getPaths().keySet()) {
+            Path path = swagger.getPath(pathname);
+            if (path.getOperations() == null) {
+                continue;
+            }
+            for (Operation operation : path.getOperations()) {
+                if (!operation.getVendorExtensions().keySet().contains("x-gatling-path")) {
+                    if (pathname.contains("{")) {
+                        String gatlingPath = pathname.replaceAll("\\{", "\\$\\{");
+                        operation.setVendorExtension("x-gatling-path", gatlingPath);
+                    } else {
+                        operation.setVendorExtension("x-gatling-path", pathname);
+                    }
+                }
+
+                Set<Parameter> headerParameters = new HashSet<>();
+                Set<Parameter> formParameters = new HashSet<>();
+                Set<Parameter> queryParameters = new HashSet<>();
+                Set<Parameter> pathParameters = new HashSet<>();
+
+                for (Parameter parameter : operation.getParameters()) {
+                    if (parameter.getIn().equalsIgnoreCase("header")) {
+                        headerParameters.add(parameter);
+                    }
+                    if (parameter.getIn().equalsIgnoreCase("formData")) {
+                        formParameters.add(parameter);
+                    }
+                    if (parameter.getIn().equalsIgnoreCase("query")) {
+                        queryParameters.add(parameter);
+                    }
+                    if (parameter.getIn().equalsIgnoreCase("path")) {
+                        pathParameters.add(parameter);
+                    }
+                    if (parameter.getIn().equalsIgnoreCase("body")) {
+                        BodyParameter bodyParameter = (BodyParameter) parameter;
+                        Model model = bodyParameter.getSchema();
+                        if (model instanceof RefModel) {
+                            String[] refArray = model.getReference().split("\\/");
+                            operation.setVendorExtension("x-gatling-body-object", refArray[refArray.length - 1] + ".toStringBody");
+                            Set<String> bodyFeederParams = new HashSet<>();
+                            Set<String> sessionBodyVars = new HashSet<>();
+                            for (Map.Entry<String, Model> modelEntry : swagger.getDefinitions().entrySet()) {
+                                if (refArray[refArray.length - 1].equalsIgnoreCase(modelEntry.getKey())) {
+                                    for (Map.Entry<String, Property> propertyEntry : modelEntry.getValue().getProperties().entrySet()) {
+                                        bodyFeederParams.add(propertyEntry.getKey());
+                                        sessionBodyVars.add("\"${" + propertyEntry.getKey() + "}\"");
+                                    }
+                                }
+                            }
+                            operation.setVendorExtension("x-gatling-body-feeder", operation.getOperationId() + "BodyFeeder");
+                            operation.setVendorExtension("x-gatling-body-feeder-params", StringUtils.join(sessionBodyVars, ","));
+                            try {
+                                FileUtils.writeStringToFile(new File(outputFolder + File.separator + dataFolder + File.separator + operation.getOperationId() + "-" + "bodyParams.csv"), StringUtils.join(bodyFeederParams, ","));
+                            } catch (IOException ioe) {
+                                LOGGER.error("Could not create feeder file for operationId" + operation.getOperationId(), ioe);
+                            }
+
+                        } else if (model instanceof ArrayModel) {
+                            operation.setVendorExtension("x-gatling-body-object", "StringBody(\"[]\")");
+                        } else {
+                            operation.setVendorExtension("x-gatling-body-object", "StringBody(\"{}\")");
+                        }
+
+                    }
+                }
+
+                prepareGatlingData(operation, headerParameters, "header");
+                prepareGatlingData(operation, formParameters, "form");
+                prepareGatlingData(operation, queryParameters, "query");
+                prepareGatlingData(operation, pathParameters, "path");
+            }
+        }
+
+    }
+
+    /**
+     * Creates all the necessary swagger vendor extensions and feeder files for gatling
+     *
+     * @param operation     Swagger Operation
+     * @param parameters    Swagger Parameters
+     * @param parameterType Swagger Parameter Type
+     */
+    private void prepareGatlingData(Operation operation, Set<Parameter> parameters, String parameterType) {
+        if (parameters.size() > 0) {
+            List<String> parameterNames = new ArrayList<>();
+            List<Object> vendorList = new ArrayList<>();
+            for (Parameter parameter : parameters) {
+                Map<String, Object> extensionMap = new HashMap<>();
+                extensionMap.put("gatlingParamName", parameter.getName());
+                extensionMap.put("gatlingParamValue", "${" + parameter.getName() + "}");
+                vendorList.add(extensionMap);
+                parameterNames.add(parameter.getName());
+            }
+            operation.setVendorExtension("x-gatling-" + parameterType.toLowerCase() + "-params", vendorList);
+            operation.setVendorExtension("x-gatling-" + parameterType.toLowerCase() + "-feeder", operation.getOperationId() + parameterType.toUpperCase() + "Feeder");
+            try {
+                FileUtils.writeStringToFile(new File(outputFolder + File.separator + dataFolder + File.separator + operation.getOperationId() + "-" + parameterType.toLowerCase() + "Params.csv"), StringUtils.join(parameterNames, ","));
+            } catch (IOException ioe) {
+                LOGGER.error("Could not create feeder file for operationId" + operation.getOperationId(), ioe);
+            }
+        }
+    }
+
+    /**
+     * Optional - type declaration.  This is a String which is used by the templates to instantiate your
+     * types.  There is typically special handling for different property types
+     *
+     * @return a string value used as the `dataType` field for model templates, `returnType` for api templates
+     */
+    @Override
+    public String getTypeDeclaration(Property p) {
+        if (p instanceof ArrayProperty) {
+            ArrayProperty ap = (ArrayProperty) p;
+            Property inner = ap.getItems();
+            return getSwaggerType(p) + "[" + getTypeDeclaration(inner) + "]";
+        } else if (p instanceof MapProperty) {
+            MapProperty mp = (MapProperty) p;
+            Property inner = mp.getAdditionalProperties();
+            return getSwaggerType(p) + "[String, " + getTypeDeclaration(inner) + "]";
+        }
+        return super.getTypeDeclaration(p);
+    }
+
+    /**
+     * Optional - swagger type conversion.  This is used to map swagger types in a `Property` into
+     * either language specific types via `typeMapping` or into complex models if there is not a mapping.
+     *
+     * @return a string value of the type or complex model for this property
+     * @see io.swagger.models.properties.Property
+     */
+    @Override
+    public String getSwaggerType(Property p) {
+        String swaggerType = super.getSwaggerType(p);
+        String type = null;
+        if (typeMapping.containsKey(swaggerType)) {
+            type = typeMapping.get(swaggerType);
+            if (languageSpecificPrimitives.contains(type))
+                return toModelName(type);
+        } else
+            type = swaggerType;
+        return toModelName(type);
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
+++ b/modules/swagger-codegen/src/main/resources/META-INF/services/io.swagger.codegen.CodegenConfig
@@ -66,3 +66,4 @@ io.swagger.codegen.languages.ErlangServerCodegen
 io.swagger.codegen.languages.UndertowCodegen
 io.swagger.codegen.languages.JavaMSF4JServerCodegen
 io.swagger.codegen.languages.ZendExpressivePathHandlerServerCodegen
+io.swagger.codegen.languages.ScalaGatlingCodegen

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/api.mustache
@@ -5,8 +5,7 @@ import {{modelPackage}}._
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 
-object {{classname}}Operations {
-{{#operations}}{{#operation}}
+object {{classname}}Operations { {{#operations}}{{#operation}}
     {{#description}}/* {{{description}}} */{{/description}}
     def {{operationId}} = http("{{operationId}}")
         .httpRequest("{{httpMethod}}","{{{vendorExtensions.x-gatling-path}}}")
@@ -25,7 +24,5 @@ object {{classname}}Operations {
     {{/vendorExtensions.x-gatling-form-params}}
     {{#vendorExtensions.x-gatling-body-object}}
         .body(StringBody(
-            {{{vendorExtensions.x-gatling-body-object}}}{{#vendorExtensions.x-gatling-body-feeder-params}}({{{vendorExtensions.x-gatling-body-feeder-params}}}){{/vendorExtensions.x-gatling-body-feeder-params}}))
-    {{/vendorExtensions.x-gatling-body-object}}
-    {{/operation}}{{/operations}}
+            {{{vendorExtensions.x-gatling-body-object}}}{{#vendorExtensions.x-gatling-body-feeder-params}}({{{vendorExtensions.x-gatling-body-feeder-params}}}){{/vendorExtensions.x-gatling-body-feeder-params}})){{/vendorExtensions.x-gatling-body-object}}{{/operation}}{{/operations}}
 }

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/api.mustache
@@ -1,0 +1,31 @@
+package {{package}}
+
+import {{modelPackage}}._
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+object {{classname}}Operations {
+{{#operations}}{{#operation}}
+    {{#description}}/* {{{description}}} */{{/description}}
+    def {{operationId}} = http("{{operationId}}")
+        .httpRequest("{{httpMethod}}","{{{vendorExtensions.x-gatling-path}}}")
+        .header("Content-Type", "application/json")
+    {{#vendorExtensions.x-gatling-header-params}}
+        .header("{{gatlingParamName}}","{{gatlingParamValue}}")
+    {{/vendorExtensions.x-gatling-header-params}}
+    {{#vendorExtensions.x-gatling-query-params}}
+        .queryParam("{{gatlingParamName}}","{{gatlingParamValue}}")
+    {{/vendorExtensions.x-gatling-query-params}}
+    {{#vendorExtensions.x-gatling-header-params}}
+        .header("{{gatlingParamName}}","{{gatlingParamValue}}")
+    {{/vendorExtensions.x-gatling-header-params}}
+    {{#vendorExtensions.x-gatling-form-params}}
+        .formParam("{{gatlingParamName}}","{{gatlingParamValue}}")
+    {{/vendorExtensions.x-gatling-form-params}}
+    {{#vendorExtensions.x-gatling-body-object}}
+        .body(StringBody(
+            {{{vendorExtensions.x-gatling-body-object}}}{{#vendorExtensions.x-gatling-body-feeder-params}}({{{vendorExtensions.x-gatling-body-feeder-params}}}){{/vendorExtensions.x-gatling-body-feeder-params}}))
+    {{/vendorExtensions.x-gatling-body-object}}
+    {{/operation}}{{/operations}}
+}

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/build.gradle
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'com.github.lkishalmi.gatling' version '0.4.1'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+
+}
+
+apply plugin: "com.github.lkishalmi.gatling"
+
+gatling {
+    toolVersion = '2.3.0'
+    jvmArgs = ['-server', '-XX:+UseThreadPriorities',
+               '-XX:ThreadPriorityPolicy=42',
+               '-Xms2048M', '-Xmx2048M', '-Xmn500M',
+               '-XX:+HeapDumpOnOutOfMemoryError',
+               '-XX:+AggressiveOpts',
+               '-XX:+OptimizeStringConcat',
+               '-XX:+UseFastAccessorMethods',
+               '-XX:+UseParNewGC',
+               '-XX:+UseConcMarkSweepGC',
+               '-XX:+CMSParallelRemarkEnabled',
+               '-Djava.net.preferIPv4Stack=true',
+               '-Djava.net.preferIPv6Addresses=false']
+}

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/default.conf.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/default.conf.mustache
@@ -1,0 +1,51 @@
+performance {
+    authorizationHeader = "~MANUAL_ENTRY~"
+    rampUpSeconds = 60
+    rampDownSeconds = 60
+    durationSeconds = 360
+    contentType = "application/json"
+    acceptType = "application/json"
+    rateMultiplier = 1
+    instanceMultiplier = 1
+    operationsPerSecond {
+    {{#apiInfo}}
+    {{#apis}}
+    {{#operations}}
+    {{#operation}}
+        {{operationId}} = 1
+    {{/operation}}
+    {{/operations}}
+    {{/apis}}
+    {{/apiInfo}}
+    }
+    global {
+        assertions {
+            responseTime {
+                min {
+                    lte = 30000
+                    gte = 0
+                }
+                max {
+                    lte = 30000
+                    gte = 0
+                }
+                mean {
+                    lte = 30000
+                    gte = 0
+                }
+            }
+            failedRequests {
+                percent {
+                    lte = 5
+                    gte = 0
+                }
+            }
+            successfulRequests {
+                percent {
+                    lte = 100
+                    gte = 0
+                }
+            }
+        }
+    }
+}

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/gatling.conf
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/gatling.conf
@@ -1,0 +1,132 @@
+#########################
+# Gatling Configuration #
+#########################
+
+# This file contains all the settings configurable for Gatling with their default values
+
+gatling {
+  core {
+    outputDirectoryBaseName = "" # The prefix for each simulation result folder (then suffixed by the report generation timestamp)
+    runDescription = ""          # The description for this simulation run, displayed in each report
+    encoding = "utf-8"           # Encoding to use throughout Gatling for file and string manipulation
+    simulationClass = ""         # The FQCN of the simulation to run (when used in conjunction with noReports, the simulation for which assertions will be validated)
+    mute = false                 # When set to true, don't ask for simulation name nor run description (currently only used by Gatling SBT plugin)
+    elFileBodiesCacheMaxCapacity = 200        # Cache size for request body EL templates, set to 0 to disable
+    rawFileBodiesCacheMaxCapacity = 200       # Cache size for request body Raw templates, set to 0 to disable
+    rawFileBodiesInMemoryMaxSize = 1000       # Below this limit, raw file bodies will be cached in memory
+    pebbleFileBodiesCacheMaxCapacity = 200    # Cache size for request body Peeble templates, set to 0 to disable
+
+    extract {
+      regex {
+        cacheMaxCapacity = 200 # Cache size for the compiled regexes, set to 0 to disable caching
+      }
+      xpath {
+        cacheMaxCapacity = 200 # Cache size for the compiled XPath queries,  set to 0 to disable caching
+      }
+      jsonPath {
+        cacheMaxCapacity = 200 # Cache size for the compiled jsonPath queries, set to 0 to disable caching
+        preferJackson = false  # When set to true, prefer Jackson over Boon for JSON-related operations
+      }
+      css {
+        cacheMaxCapacity = 200 # Cache size for the compiled CSS selectors queries,  set to 0 to disable caching
+      }
+    }
+
+    directory {
+      data = user-files/data               # Folder where user's data (e.g. files used by Feeders) is located
+      bodies = user-files/bodies           # Folder where bodies are located
+      simulations = user-files/simulations # Folder where the bundle's simulations are located
+      reportsOnly = ""                     # If set, name of report folder to look for in order to generate its report
+      binaries = ""                        # If set, name of the folder where compiles classes are located: Defaults to GATLING_HOME/target.
+      results = results                    # Name of the folder where all reports folder are located
+    }
+  }
+  charting {
+    noReports = false       # When set to true, don't generate HTML reports
+    maxPlotPerSeries = 1000 # Number of points per graph in Gatling reports
+    useGroupDurationMetric = false  # Switch group timings from cumulated response time to group duration.
+    indicators {
+      lowerBound = 800      # Lower bound for the requests' response time to track in the reports and the console summary
+      higherBound = 1200    # Higher bound for the requests' response time to track in the reports and the console summary
+      percentile1 = 50      # Value for the 1st percentile to track in the reports, the console summary and Graphite
+      percentile2 = 75      # Value for the 2nd percentile to track in the reports, the console summary and Graphite
+      percentile3 = 95      # Value for the 3rd percentile to track in the reports, the console summary and Graphite
+      percentile4 = 99      # Value for the 4th percentile to track in the reports, the console summary and Graphite
+    }
+  }
+  http {
+    fetchedCssCacheMaxCapacity = 200          # Cache size for CSS parsed content, set to 0 to disable
+    fetchedHtmlCacheMaxCapacity = 200         # Cache size for HTML parsed content, set to 0 to disable
+    perUserCacheMaxCapacity = 200             # Per virtual user cache size, set to 0 to disable
+    warmUpUrl = "http://gatling.io"           # The URL to use to warm-up the HTTP stack (blank means disabled)
+    enableGA = true                           # Very light Google Analytics, please support
+    ssl {
+      keyStore {
+        type = ""      # Type of SSLContext's KeyManagers store
+        file = ""      # Location of SSLContext's KeyManagers store
+        password = ""  # Password for SSLContext's KeyManagers store
+        algorithm = "" # Algorithm used SSLContext's KeyManagers store
+      }
+      trustStore {
+        type = ""      # Type of SSLContext's TrustManagers store
+        file = ""      # Location of SSLContext's TrustManagers store
+        password = ""  # Password for SSLContext's TrustManagers store
+        algorithm = "" # Algorithm used by SSLContext's TrustManagers store
+      }
+    }
+    ahc {
+      keepAlive = true                                    # Allow pooling HTTP connections (keep-alive header automatically added)
+      connectTimeout = 10000                              # Timeout when establishing a connection
+      handshakeTimeout = 10000                            # Timeout when performing TLS hashshake
+      pooledConnectionIdleTimeout = 60000                 # Timeout when a connection stays unused in the pool
+      readTimeout = 60000                                 # Timeout when a used connection stays idle
+      maxRetry = 2                                        # Number of times that a request should be tried again
+      requestTimeout = 60000                              # Timeout of the requests
+      disableHttpsEndpointIdentificationAlgorithm = true  # When set to true, don't enable SSL algorithm on the SSLEngine
+      useInsecureTrustManager = true                      # Use an insecure TrustManager that trusts all server certificates
+      httpClientCodecMaxChunkSize = 8192                  # Maximum length of the content or each chunk
+      httpClientCodecInitialBufferSize = 128              # Initial HttpClientCodec buffer size
+      sslEnabledProtocols = [TLSv1.2, TLSv1.1, TLSv1]     # Array of enabled protocols for HTTPS, if empty use the JDK defaults
+      sslEnabledCipherSuites = []                         # Array of enabled cipher suites for HTTPS, if empty use the AHC defaults
+      sslSessionCacheSize = 0                             # SSLSession cache size, set to 0 to use JDK's default
+      sslSessionTimeout = 0                               # SSLSession timeout in seconds, set to 0 to use JDK's default (24h)
+      useOpenSsl = false                                  # if OpenSSL should be used instead of JSSE (requires tcnative jar)
+      useNativeTransport = false                          # if native transport should be used instead of Java NIO (requires netty-transport-native-epoll, currently Linux only)
+      tcpNoDelay = true
+      soReuseAddress = false
+      soLinger = -1
+      soSndBuf = -1
+      soRcvBuf = -1
+      allocator = "pooled"                            # switch to unpooled for unpooled ByteBufAllocator
+      maxThreadLocalCharBufferSize = 200000           # Netty's default is 16k
+    }
+    dns {
+      queryTimeout = 5000                             # Timeout of each DNS query in millis
+      maxQueriesPerResolve = 6                        # Maximum allowed number of DNS queries for a given name resolution
+    }
+  }
+  jms {
+    replyTimeoutScanPeriod = 1000  # scan period for timedout reply messages
+  }
+  data {
+    writers = [console, file]      # The list of DataWriters to which Gatling write simulation data (currently supported : console, file, graphite, jdbc)
+    console {
+      light = false                # When set to true, displays a light version without detailed request stats
+    }
+    file {
+      bufferSize = 8192            # FileDataWriter's internal data buffer size, in bytes
+    }
+    leak {
+      noActivityTimeout = 30  # Period, in seconds, for which Gatling may have no activity before considering a leak may be happening
+    }
+    graphite {
+      light = false              # only send the all* stats
+      host = "localhost"         # The host where the Carbon server is located
+      port = 2003                # The port to which the Carbon server listens to (2003 is default for plaintext, 2004 is default for pickle)
+      protocol = "tcp"           # The protocol used to send data to Carbon (currently supported : "tcp", "udp")
+      rootPathPrefix = "gatling" # The common prefix of all metrics sent to Graphite
+      bufferSize = 8192          # GraphiteDataWriter's internal data buffer size, in bytes
+      writeInterval = 1          # GraphiteDataWriter's write interval, in seconds
+    }
+  }
+}

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/logback.xml
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+        </encoder>
+        <immediateFlush>false</immediateFlush>
+    </appender>
+
+    <!-- Uncomment for logging ALL HTTP request and responses -->
+    <!-- 	<logger name="io.gatling.http.ahc" level="TRACE" /> -->
+    <!--    <logger name="io.gatling.http.response" level="TRACE" /> -->
+    <!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
+    <!-- 	<logger name="io.gatling.http.ahc" level="DEBUG" /> -->
+    <!--    <logger name="io.gatling.http.response" level="DEBUG" /> -->
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/model.mustache
@@ -1,15 +1,14 @@
 package {{package}}
 
-{{#imports}}import {{import}}
-{{/imports}}
-
+{{#imports}}import {{import}}{{/imports}}
 {{#models}}{{#model}}
 case class {{classname}} (
     {{#vars}}
-     {{#description}}/* {{{description}}} */{{/description}}
-      _{{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}] = None{{/required}}{{#hasMore}},{{/hasMore}}
+    {{#description}}/* {{{description}}} */{{/description}}
+    _{{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}] = None{{/required}}{{#hasMore}},{{/hasMore}}
     {{/vars}}
 )
+
 object {{classname}} {
     def toStringBody({{#vars}}var_{{name}}: {{^required}}{{/required}}Object{{^required}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/vars}}) =
         s"""

--- a/modules/swagger-codegen/src/main/resources/scala-gatling/model.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala-gatling/model.mustache
@@ -1,0 +1,21 @@
+package {{package}}
+
+{{#imports}}import {{import}}
+{{/imports}}
+
+{{#models}}{{#model}}
+case class {{classname}} (
+    {{#vars}}
+     {{#description}}/* {{{description}}} */{{/description}}
+      _{{{name}}}: {{^required}}Option[{{/required}}{{datatype}}{{^required}}] = None{{/required}}{{#hasMore}},{{/hasMore}}
+    {{/vars}}
+)
+object {{classname}} {
+    def toStringBody({{#vars}}var_{{name}}: {{^required}}{{/required}}Object{{^required}}{{/required}}{{#hasMore}}, {{/hasMore}}{{/vars}}) =
+        s"""
+        | {
+        | {{#vars}}"{{{name}}}":$var_{{{name}}}{{#hasMore}},{{/hasMore}}{{/vars}}
+        | }
+        """.stripMargin
+}
+{{/model}}{{/models}}

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.6-elastic-cloud</version>
+        <version>2.2.7-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>swagger-codegen-project</artifactId>
     <packaging>pom</packaging>
     <name>swagger-codegen-project</name>
-    <version>2.2.6-elastic-cloud</version>
+    <version>2.2.7-elastic-cloud</version>
     <url>https://github.com/elastic/swagger-codegen</url>
     <scm>
         <connection>scm:git:git@github.com:elastic/swagger-codegen.git</connection>


### PR DESCRIPTION
### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell/batch script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates)
- [ ] Filed the PR against the correct branch: master for non-breaking changes and `2.3.0` branch for breaking (non-backward compatible) changes.

### Description of the PR

This PR adds `ScalaGatlingCodegen.java` client to the list of existing ones.
The purpose of this client is to generate Gatling scripts out of our json api description. The client itself almost fully duplicates the one in the official `swagger-codegen` repo but `api.mustache` and `model.mustache` template files were edited by me to meet our load-test project.

When we are ready to get rid of the custom version of swagger-codegen, we'll need to transfer template files to the load-test project. 


