### PR TITLE
Fix adding ?& twice to urls

### DIFF
--- a/modules/swagger-codegen-cli/pom.xml
+++ b/modules/swagger-codegen-cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.7-elastic-cloud</version>
+        <version>2.2.8-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen-maven-plugin/pom.xml
+++ b/modules/swagger-codegen-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.7-elastic-cloud</version>
+        <version>2.2.8-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-codegen-maven-plugin</artifactId>

--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.7-elastic-cloud</version>
+        <version>2.2.8-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
+++ b/modules/swagger-codegen/src/main/resources/scala/apiInvoker.mustache
@@ -140,7 +140,7 @@ class ApiInvoker(val mapper: ObjectMapper = ScalaJsonUtil.getJsonMapper,
   def invokeApi(host: String, path: String, method: String, queryParams: Map[String, String], formParams: Map[String, String], body: AnyRef, headerParams: Map[String, String], contentType: String): String = {
     val client = getClient(host)
 
-    val normalisedQueryParams = queryParams.filter(k => k._2 != null).map(k => (escape(k._1) + "=" + escape(k._2))).mkString("?", "&", "")
+    val normalisedQueryParams = queryParams.filter(k => k._2 != null).map(k => (escape(k._1) + "=" + escape(k._2)))
 
     val normalisedQuery = if(normalisedQueryParams.nonEmpty) {
       normalisedQueryParams.mkString("?", "&", "")

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.7-elastic-cloud</version>
+        <version>2.2.8-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>swagger-codegen-project</artifactId>
     <packaging>pom</packaging>
     <name>swagger-codegen-project</name>
-    <version>2.2.7-elastic-cloud</version>
+    <version>2.2.8-elastic-cloud</version>
     <url>https://github.com/elastic/swagger-codegen</url>
     <scm>
         <connection>scm:git:git@github.com:elastic/swagger-codegen.git</connection>


### PR DESCRIPTION
Fixing changes from #15

Those changes added the ? and & twice making this URL:
`http://localhost:12300/api/v1/deployments?validate_only=true`
to be normalized to this one:
`http://localhost:12300/api/v1/deployments??&v&a&l&i&d&a&t&e&_&o&n&l&y&=&t&r&u&e`
