### PR TITLE
Fix: Update artifactory urls to https://artifactory.elastic.dev

### DIFF
--- a/modules/swagger-codegen-cli/pom.xml
+++ b/modules/swagger-codegen-cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.9-elastic-cloud</version>
+        <version>2.2.10-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-codegen-maven-plugin/pom.xml
+++ b/modules/swagger-codegen-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.9-elastic-cloud</version>
+        <version>2.2.10-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-codegen-maven-plugin</artifactId>

--- a/modules/swagger-codegen/pom.xml
+++ b/modules/swagger-codegen/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.9-elastic-cloud</version>
+        <version>2.2.10-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-generator/pom.xml
+++ b/modules/swagger-generator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-project</artifactId>
-        <version>2.2.9-elastic-cloud</version>
+        <version>2.2.10-elastic-cloud</version>
         <relativePath>../..</relativePath>
     </parent>
     <artifactId>swagger-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -910,8 +910,8 @@
         </repository>
         <snapshotRepository>
             <id>snapshots</id>
-            <name> cloud-snapshot-local</name>
-            <url> https://artifactory.elastic.dev/artifactory/cloud-snapshot-local</url>
+            <name>cloud-snapshot-local</name>
+            <url>https://artifactory.elastic.dev/artifactory/cloud-snapshot-local</url>
         </snapshotRepository>
     </distributionManagement>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -905,13 +905,13 @@
     <distributionManagement>
         <repository>
             <id>central</id>
-            <name>artifactory.elstc.co-cloud-releases</name>
-            <url>https://artifactory.elstc.co/artifactory/cloud-release-local</url>
+            <name>cloud-release-local</name>
+            <url>https://artifactory.elastic.dev/artifactory/cloud-release-local</url>
         </repository>
         <snapshotRepository>
             <id>snapshots</id>
-            <name>artifactory.elstc.co-cloud-snapshots</name>
-            <url>https://artifactory.elstc.co/artifactory/cloud-snapshot-local</url>
+            <name> cloud-snapshot-local</name>
+            <url> https://artifactory.elastic.dev/artifactory/cloud-snapshot-local</url>
         </snapshotRepository>
     </distributionManagement>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>swagger-codegen-project</artifactId>
     <packaging>pom</packaging>
     <name>swagger-codegen-project</name>
-    <version>2.2.9-elastic-cloud</version>
+    <version>2.2.10-elastic-cloud</version>
     <url>https://github.com/elastic/swagger-codegen</url>
     <scm>
         <connection>scm:git:git@github.com:elastic/swagger-codegen.git</connection>


### PR DESCRIPTION
When trying to deploy the `swagger-codegen` I found out that repository urls in `distributionManagement` section pointed to the old artifactory url. 
- Fixing it to point to `https://artifactory.elastic.dev/..` 
- Bumping the version to 2.2.10

rel: https://github.com/elastic/cloud/issues/74070

