### PR TITLE
Update deploy section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ The Cloud team relies on the Scala and Java clients, generated from our [OpenAPI
     - [swagger-codegen-cli pom.xml](https://github.com/elastic/swagger-codegen/blob/master/modules/swagger-codegen-cli/pom.xml)
     - [swagger-codegen-maven-plugin pom.xml](https://github.com/elastic/swagger-codegen/blob/master/modules/swagger-codegen-maven-plugin/pom.xml)
     - [swagger-generator pom.xml](https://github.com/elastic/swagger-codegen/blob/master/modules/swagger-generator/pom.xml)
-  - Run [this Jenkins job](https://ci-staging.found.no/job/cloud-swagger-codegen-fork/) to publish the Maven artifacts:
-    - First, run the `clean package` goal (`master` branch by default)
-    - Then, run the `deploy` goal  (`master` branch by default)
+  - CI-Staging [Jenkins job](https://ci-staging.found.no/job/cloud-swagger-codegen-fork/) is no longer working way to publish Maven Artifacts. Instead, when a PR is merged to master, artifacts need to be packaged locally:
+    - Run `mvn clean package` target from the master branch.
+    - Then, there are two possible ways:
+        1) Run  `mvn -Darguments=-DskipTests clean deploy` target to deploy to Artifactory. For that you need to have local `~/.m2/settings.xml` configured.
+        2) Deploy using [Artifactory](https://artifactory.elastic.dev/ui/repos/tree/General/cloud-release) UI `Deploy` button
+
+#### A quick guide on how to configure `settings.xml` file:
+[Artifactory](https://artifactory.elastic.dev/) provides a nice UI to help to setup settings file:
+- Go to the `Artifacts` section (left column)
+- Click the `Set Me Up` button on the top right
+- Choose `cloud-release-local` repository
+- Click `Generate Maven Settings` and copy generated file
+- To deploy, you'll need to replace username with your `@elastic.co` email and password with the `API Key` generated in the `Edit Profile` section:
+  ```
+  <username>${security.getCurrentUsername()}</username>
+  <password>${security.getEscapedEncryptedPassword()!"*** Insert encrypted password here ***"</password>
+  ```


### PR DESCRIPTION
Unfortunately It's not possible anymore to deploy **swagger-codegen** with https://ci-staging.found.no/job/cloud-swagger-codegen-fork because there's a plan to shut it down: https://github.com/elastic/cloud/issues/66564

Now we need to do deploy ourselves, after PR is merged, so updating readme to make this easier for next deployers 